### PR TITLE
Move reset button outside result actions and style as danger

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -219,7 +219,7 @@ document.addEventListener('DOMContentLoaded', function() {
         resultElement.style.display = 'block';
         exportButton.style.display = 'inline-block';
         backButton.style.display = 'inline-block';
-        resetButton.style.display = 'inline-block';
+        resetButton.style.display = 'block';
 
         // Ajuste para melhor visualização do resultado
         window.scrollTo(0, 0); // Opcional: rola a página para o topo para exibir o resultado

--- a/index.html
+++ b/index.html
@@ -421,8 +421,8 @@
             <div class="result-buttons" style="margin-top:20px;">
                 <button type="button" id="exportButton" class="btn btn-secondary">Exportar Relatório</button>
                 <button type="button" id="backButton" class="btn btn-primary">Voltar ao Questionário</button>
-                <button type="button" id="resetButton" class="btn btn-info">Reset</button>
             </div>
+            <button type="button" id="resetButton" class="btn btn-danger">Reset</button>
         </div>
     </main>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -237,6 +237,13 @@ select:focus {
 .btn-success:hover {
     background-color: #218838;
 }
+
+.btn-danger {
+    background-color: #dc3545;
+    color: white;
+    display: block;
+    margin: 20px auto;
+}
 #snot-20-form, .question-group {
     display: none;
 }


### PR DESCRIPTION
## Summary
- Place the reset button below the result actions and style it as a danger button for visibility.
- Add a `.btn-danger` style for the reset button with centered block layout and red color.
- Update logic to show the reset button as a block element.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae5833af30832bb1575030f4dc86b3