### PR TITLE
Add score classification and include in PDF and interface

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -10,6 +10,17 @@ function getScoreColor(score) {
     return { fontColor: 'black', backgroundColor: 'transparent' };
 }
 
+function getScoreClassification(score) {
+    if (score >= 0 && score <= 36) {
+        return 'Impacto leve';
+    } else if (score >= 37 && score <= 74) {
+        return 'Impacto moderado';
+    } else if (score >= 75 && score <= 110) {
+        return 'Impacto grave';
+    }
+    return '';
+}
+
 if (typeof document !== 'undefined') {
 document.addEventListener('DOMContentLoaded', function() {
 
@@ -208,6 +219,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     
         const scoreHtml = `<h2 style="margin-top: 0;">Pontuação SNOT-22: <strong>${score}</strong></h2>`;
+        const classificationHtml = `<p>${getScoreClassification(score)}</p>`;
         const impactHtml = `<p>Uma pontuação mais alta indica uma pior qualidade de vida.</p>`;
         let symptomsListHtml = '<h3>Piores Sintomas:</h3><ul>';
         for (let symptom of top5SymptomsLabels) {
@@ -215,7 +227,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         symptomsListHtml += '</ul>';
     
-        resultElement.innerHTML = `${scoreHtml}${impactHtml}${symptomsListHtml}`;
+        resultElement.innerHTML = `${scoreHtml}${classificationHtml}${impactHtml}${symptomsListHtml}`;
         resultElement.style.display = 'block';
         exportButton.style.display = 'inline-block';
         backButton.style.display = 'inline-block';
@@ -247,6 +259,8 @@ document.addEventListener('DOMContentLoaded', function() {
         doc.text(`Pontuação SNOT-22: ${lastScore}`, 10, y);
         y += 10;
         doc.setTextColor(0, 0, 0);
+        doc.text(getScoreClassification(lastScore), 10, y);
+        y += 10;
         doc.text('Sintomas mais impactantes:', 10, y);
         y += 10;
         lastTopSymptoms.forEach(symptom => {
@@ -281,6 +295,6 @@ document.addEventListener('DOMContentLoaded', function() {
 }
 
 if (typeof module !== 'undefined') {
-    module.exports = { getScoreColor };
+    module.exports = { getScoreColor, getScoreClassification };
 }
 

--- a/calculator.test.js
+++ b/calculator.test.js
@@ -31,6 +31,35 @@ describe('getScoreColor', () => {
   });
 });
 
+describe('getScoreClassification', () => {
+  const { getScoreClassification } = require('./calculator');
+
+  test('returns low impact message for low scores', () => {
+    expect(getScoreClassification(10)).toBe('Impacto leve');
+  });
+
+  test('returns moderate impact message for medium scores', () => {
+    expect(getScoreClassification(50)).toBe('Impacto moderado');
+  });
+
+  test('returns high impact message for high scores', () => {
+    expect(getScoreClassification(100)).toBe('Impacto grave');
+  });
+
+  test('uses low impact message for boundary score 36', () => {
+    expect(getScoreClassification(36)).toBe('Impacto leve');
+  });
+
+  test('uses moderate impact message for boundary scores 37 and 74', () => {
+    expect(getScoreClassification(37)).toBe('Impacto moderado');
+    expect(getScoreClassification(74)).toBe('Impacto moderado');
+  });
+
+  test('uses high impact message for boundary score 75', () => {
+    expect(getScoreClassification(75)).toBe('Impacto grave');
+  });
+});
+
 function setupDOM() {
   document.body.innerHTML = `
     <button id="startButton"></button>


### PR DESCRIPTION
## Summary
- add getScoreClassification helper for low, moderate, and high impact ranges
- show score classification in result UI and PDF export
- cover score classification with new unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aede7bbf64832baa88b834171a0275